### PR TITLE
Fix: Resolve infinite authentication loop

### DIFF
--- a/components/auth/AuthGuard.tsx
+++ b/components/auth/AuthGuard.tsx
@@ -1,16 +1,9 @@
 import { useSession } from 'next-auth/react'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+// import { useRouter } from 'next/router' // No longer needed for redirect
+// import { useEffect } from 'react' // No longer needed
 
 const AuthGuard = ({ children }: { children: React.ReactNode }) => {
   const { status } = useSession()
-  const router = useRouter()
-
-  useEffect(() => {
-    if (status === 'unauthenticated') {
-      router.push(`/login?callbackUrl=${encodeURIComponent(router.asPath)}`)
-    }
-  }, [status, router])
 
   if (status === 'loading') {
     return (


### PR DESCRIPTION
- Modified AuthGuard to remove client-side redirect logic, which conflicted with middleware and page-level redirects, causing an infinite loop.
- AuthGuard now primarily handles loading UI and conditional rendering based on session status, relying on middleware for route protection.
- Reviewed middleware and confirmed its robustness for the current authentication flow.